### PR TITLE
New apache-php image

### DIFF
--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -1,5 +1,4 @@
-FROM tutum/apache-php
-
+FROM ubuntu:trusty
 MAINTAINER Dan Farrelly <dan@buffer.com>
 
 # Add sources for Mongo drivers
@@ -9,12 +8,22 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 ;\
 
 RUN apt-get update
 RUN apt-get -yq install \
-    git-all \
-    php5-dev \
-    php5-cli \
-    php5-imagick \
-    build-essential \
-    libmemcached-dev
+      build-essential \
+      apache2 \
+      libapache2-mod-php5 \
+      libmemcached-dev \
+      php-pear \
+      libcurl3 \
+      php5 \
+      php5-dev \
+      php5-curl \
+      php5-cli \
+      curl \
+      git-core \
+      php5-imagick \
+      php5-gd \
+      php5-mcrypt
+RUN /usr/sbin/php5enmod mcrypt
 
 # Drivers and libraries
 RUN /usr/bin/pecl install -f mongo-1.5.8
@@ -37,5 +46,23 @@ COPY php.ini /etc/php5/cli/php.ini
 RUN /usr/bin/pear config-set php_ini /etc/php5/apache2/php.ini ;\
   /usr/bin/pecl config-set php_ini /etc/php5/apache2/php.ini
 
+ENV ALLOW_OVERRIDE **False**
+
 RUN /usr/sbin/a2enmod expires ; /usr/sbin/a2enmod ssl ;\
   /usr/sbin/a2enmod headers ; /usr/sbin/a2enmod rewrite
+
+# Log folder for metrics and elastic search logging
+RUN mkdir -p /var/log/buffer
+RUN chmod 777 /var/log/buffer
+
+ADD run.sh /run.sh
+RUN chmod 755 /*.sh
+
+EXPOSE 80
+EXPOSE 443
+
+# Configure /app folder w/ symlink
+RUN mkdir -p /app && rm -fr /var/www/html && ln -s /app /var/www/html
+
+WORKDIR /app
+CMD ["/run.sh"]

--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -21,9 +21,7 @@ RUN apt-get -yq install \
       curl \
       git-core \
       php5-imagick \
-      php5-gd \
-      php5-mcrypt
-RUN /usr/sbin/php5enmod mcrypt
+      php5-gd
 
 # Drivers and libraries
 RUN /usr/bin/pecl install -f mongo-1.5.8

--- a/apache-php/run.sh
+++ b/apache-php/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+chown www-data:www-data /app -R
+
+if [ "$ALLOW_OVERRIDE" = "**False**" ]; then
+    unset ALLOW_OVERRIDE
+else
+    sed -i "s/AllowOverride None/AllowOverride All/g" /etc/apache2/apache2.conf
+    a2enmod rewrite
+fi
+
+source /etc/apache2/envvars
+# Tail the default buffer-log location
+tail -F /var/log/buffer/* &
+exec apache2 -D FOREGROUND


### PR DESCRIPTION
### Purpose
This removes the mcrypt module which was breaking oauth with social networks in buffer-web. This replaces the `tutum/apache-php` base image starting from `ubuntu:trusty` aka 14.04. This gives us more full control over the image for [buffer-web](https://github.com/bufferapp/buffer-web). 

### Review
Hooray @kiriappeee!!! This fixes that Oauth bug I mentioned a while back, so happy it's fixed, just wanted to cc you on this PR :smile: 