### PR TITLE
Add node-libvips image

### DIFF
--- a/node-libvips/Dockerfile
+++ b/node-libvips/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:6.3.0-slim
+
+# Inspired by from https://github.com/marcbachmann/dockerfile-libvips/blob/master/Dockerfile
+ENV LIBVIPS_VERSION_MAJOR 8
+ENV LIBVIPS_VERSION_MINOR 2
+ENV LIBVIPS_VERSION_PATCH 3
+ENV LIBVIPS_VERSION $LIBVIPS_VERSION_MAJOR.$LIBVIPS_VERSION_MINOR.$LIBVIPS_VERSION_PATCH
+
+RUN \
+
+  # Install dependencies
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  automake build-essential curl \
+  gobject-introspection gtk-doc-tools libglib2.0-dev  libjpeg62-turbo-dev \
+  libpng12-dev libwebp-dev libtiff5-dev libexif-dev libxml2-dev swig libmagickwand-dev libpango1.0-dev \
+  libmatio-dev libopenslide-dev libcfitsio3-dev && \
+
+  # Build libvips
+  curl -O http://www.vips.ecs.soton.ac.uk/supported/$LIBVIPS_VERSION_MAJOR.$LIBVIPS_VERSION_MINOR/vips-$LIBVIPS_VERSION.tar.gz && \
+  tar zvxf vips-$LIBVIPS_VERSION.tar.gz && \
+  cd vips-$LIBVIPS_VERSION && \
+  ./configure --enable-debug=no --without-python --without-orc --without-fftw --without-gsf $1 && \
+  make && \
+  make install && \
+  ldconfig && \
+
+  # Clean up
+  apt-get remove -y curl automake build-essential && \
+  apt-get autoremove -y && \
+  apt-get autoclean && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/node-libvips/README.md
+++ b/node-libvips/README.md
@@ -1,0 +1,11 @@
+# node-libvips
+
+For use with Node.js and the image conversion library [Sharp](http://sharp.readthedocs.io/en/stable/).
+
+Built on a Node.js base image and with added libvips install mostly borrowed from the
+[marcbachmann/libvips](https://github.com/marcbachmann/dockerfile-libvips/blob/master/Dockerfile)
+docker image.
+
+## Tags
+
+- [6.3.0] - Node.js 6.3.0, libvips 8.2.3

--- a/node-libvips/README.md
+++ b/node-libvips/README.md
@@ -8,4 +8,4 @@ docker image.
 
 ## Tags
 
-- [6.3.0] - Node.js 6.3.0, libvips 8.2.3
+- **6.3.0** - Node.js 6.3.0, libvips 8.2.3


### PR DESCRIPTION
### Purpose
For use with the new [buffer-images](https://github.com/bufferapp/buffer-images) service. This borrows most of the logic from the [marcbachmann/libvips](https://github.com/marcbachmann/dockerfile-libvips/blob/master/Dockerfile) docker image, but replaces the `libjpeg8-turbo-dev` package with `libjpeg62-turbo-dev` for Debian.

**Image:** [bufferapp/node-libvips on Dockerhub](https://hub.docker.com/r/bufferapp/node-libvips/)

### Review
Hey @msanroman, it seems to have installed and compiled correctly, I'd love if you replaced this as your base image in buffer-images. Instead of 'node:6.3.0-slim', use `bufferapp/node-vips:6.3.0` and let me know if that works!

