### PR TITLE
Use the new base image on newer PHP version

### DIFF
--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -1,5 +1,5 @@
-FROM php:5.5.36-apache
-MAINTAINER Dan Farrelly <dan@buffer.com>
+FROM php:5.6.28-apache
+MAINTAINER Steven Cheng <steven@buffer.com>
 
 RUN apt-get update
 RUN apt-get -yq install \


### PR DESCRIPTION
PHP 5.6 upgrade has been used in local dev already. Thought it might be safe to merge it. cc @djfarrelly , @josem :)