### PR TITLE
Upgrade to php 5.6.36 and Debian 9 stretch

### DIFF
--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Steven Cheng <steven@buffer.com>
 RUN apt-get update
 RUN apt-get -yq install \
       build-essential \
+      libmagickwand-dev \
       libmemcached-dev \
       libmcrypt-dev \
       libcurl3 \
@@ -25,12 +26,15 @@ RUN apt-get -yq install \
 #      php5-gd        # installed in Dockerfile.development
 
 RUN docker-php-ext-install mcrypt
+RUN docker-php-ext-install calendar
 
 # Drivers and libraries
 RUN pecl install -f mongo-1.5.8
 RUN pecl install -f memcached-2.2.0
 RUN pecl install -f redis-2.2.8
-RUN docker-php-ext-enable mongo memcached redis
+RUN pecl install -f imagick
+
+RUN docker-php-ext-enable mongo memcached redis imagick
 
 # Configure Apache
 COPY php.ini /usr/local/etc/php/

--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -23,15 +23,11 @@ RUN apt-get update && \
 
 # Drivers and libraries
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
-
-RUN docker-php-ext-install -j$(nproc) gd
-RUN docker-php-ext-install mcrypt
-RUN docker-php-ext-install calendar
-
-RUN pecl install -f mongo-1.5.8
-RUN pecl install -f memcached-2.2.0
-RUN pecl install -f redis-2.2.8
-RUN pecl install -f imagick
+RUN docker-php-ext-install -j$(nproc) gd mcrypt calendar
+RUN pecl install -f mongo-1.5.8 && \
+    pecl install -f memcached-2.2.0 && \
+    pecl install -f redis-2.2.8 && \
+    pecl install -f imagick
 
 RUN docker-php-ext-enable mongo memcached redis imagick
 
@@ -42,8 +38,8 @@ RUN /usr/sbin/a2enmod expires ; /usr/sbin/a2enmod ssl ;\
   /usr/sbin/a2enmod headers ; /usr/sbin/a2enmod rewrite
 
 # Log folder for metrics and elastic search logging
-RUN mkdir -p /var/log/buffer
-RUN chmod 777 /var/log/buffer
+RUN mkdir -p /var/log/buffer && \
+    chmod 777 /var/log/buffer
 
 EXPOSE 80
 EXPOSE 443

--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -1,4 +1,5 @@
-FROM php:5.6.28-apache
+FROM php:5.6.36-apache-stretch
+
 MAINTAINER Steven Cheng <steven@buffer.com>
 
 RUN apt-get update

--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -17,13 +17,17 @@ RUN apt-get -yq install \
       unzip \
       zip
 #      php-pear \     # help to install some extentions
-#      php5-dev \     # get the headers for  extensions
+#      php5-dev \     # get the headers for some extensions
 #      php5-cli \     # I don't think we need that
 
+
+# Drivers and libraries
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
+
+RUN docker-php-ext-install -j1 gd
 RUN docker-php-ext-install mcrypt
 RUN docker-php-ext-install calendar
 
-# Drivers and libraries
 RUN pecl install -f mongo-1.5.8
 RUN pecl install -f memcached-2.2.0
 RUN pecl install -f redis-2.2.8

--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -7,14 +7,22 @@ RUN apt-get -yq install \
       build-essential \
       libmemcached-dev \
       libmcrypt-dev \
-      php-pear \
       libcurl3 \
-      php5-dev \
-      php5-curl \
-      php5-cli \
-      php-calendar \
-      php5-imagick \
-      php5-gd
+      libfreetype6-dev \
+      libjpeg62-turbo-dev \
+      libjpeg-dev \
+      libpng-dev \
+      libz-dev \
+      unzip \
+      zip
+
+#      php-pear \     # help to install some extentions
+#      php5-dev \     # get the headers for  extensions
+#      php5-curl \    # already compiled in the php extentions
+#      php5-cli \     # i don't think we need that?
+#      php-calendar \ # unsure: if used in php, we would need it
+#      php5-imagick \ # unsure: if used in php, we would need it
+#      php5-gd        # installed in Dockerfile.development
 
 RUN docker-php-ext-install mcrypt
 

--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Steven Cheng <steven@buffer.com>
 RUN apt-get update
 RUN apt-get -yq install \
       build-essential \
-      libmagickwand-dev \
+      libmagickwand-dev \ 
       libmemcached-dev \
       libmcrypt-dev \
       libcurl3 \
@@ -16,14 +16,9 @@ RUN apt-get -yq install \
       libz-dev \
       unzip \
       zip
-
 #      php-pear \     # help to install some extentions
 #      php5-dev \     # get the headers for  extensions
-#      php5-curl \    # already compiled in the php extentions
-#      php5-cli \     # i don't think we need that?
-#      php-calendar \ # unsure: if used in php, we would need it
-#      php5-imagick \ # unsure: if used in php, we would need it
-#      php5-gd        # installed in Dockerfile.development
+#      php5-cli \     # I don't think we need that
 
 RUN docker-php-ext-install mcrypt
 RUN docker-php-ext-install calendar

--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && \
 
 # Drivers and libraries
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
-RUN docker-php-ext-install -j$(nproc) gd mcrypt calendar
+RUN docker-php-ext-install -j$(nproc) gd mcrypt calendar pcntl
 RUN pecl install -f mongo-1.5.8 && \
     pecl install -f memcached-2.2.0 && \
     pecl install -f redis-2.2.8 && \

--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get -yq install \
 # Drivers and libraries
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
 
-RUN docker-php-ext-install -j1 gd
+RUN docker-php-ext-install -j$(nproc) gd
 RUN docker-php-ext-install mcrypt
 RUN docker-php-ext-install calendar
 

--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -2,8 +2,8 @@ FROM php:5.6.36-apache-stretch
 
 MAINTAINER Steven Cheng <steven@buffer.com>
 
-RUN apt-get update
-RUN apt-get -yq install \
+RUN apt-get update && \
+      apt-get -yq install \
       build-essential \
       libmagickwand-dev \ 
       libmemcached-dev \

--- a/apache-php/Makefile
+++ b/apache-php/Makefile
@@ -3,7 +3,7 @@ IMG_VERSION := 5.6.36-apache-stretch
 
 .PHONY: build
 build:
-	docker build --no-cache -t $(IMG_NAME):$(IMG_VERSION) -f Dockerfile .
+	docker build -t $(IMG_NAME):$(IMG_VERSION) -f Dockerfile .
 
 .PHONY: run
 run:

--- a/apache-php/Makefile
+++ b/apache-php/Makefile
@@ -1,0 +1,15 @@
+IMG_NAME := bufferapp/apache-php
+IMG_VERSION := 5.6.36-apache-stretch
+
+.PHONY: build
+build:
+	docker build --no-cache -t $(IMG_NAME):$(IMG_VERSION) -f Dockerfile .
+
+.PHONY: run
+run:
+	docker run -it $(IMG_NAME):$(IMG_VERSION) /bin/bash
+
+.PHONY: publish
+publish:
+	@echo 'publish $(VERSION) to $(IMG_NAME)'
+	docker push $(IMG_NAME):$(IMG_VERSION)


### PR DESCRIPTION
Hey @djfarrelly @stevenc81 @kiriappeee 

This is a suggestion to upgrade for our local  image for buffer-dev (cc @kiriappeee) . I've done that mainly because I needed to run our PHP tests with API for https://github.com/bufferapp/buffer-web/pull/15104. It will also be a good php/debian version to use as a base for the upcoming migration of api to k8s.

I've removed some php-* packages that seems unnecessary , already installed with php or installed in a "destructive" way. I use the [`docker-php-*` way](https://github.com/docker-library/docs/blob/master/php/content.md#how-to-install-more-php-extensions) to setup/config php packages, that is the non-destructive and standard way to do that.

Also our PHP tests are all passing with this new image. Also tested quickly to run publish buffer-dev  with it and it looked good to me.
