### PR TITLE
Add igbinary to memcache to php apache

### DIFF
--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -25,9 +25,19 @@ RUN apt-get update && \
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
 RUN docker-php-ext-install -j$(nproc) gd mcrypt calendar pcntl
 RUN pecl install -f mongo-1.5.8 && \
-    pecl install -f memcached-2.2.0 && \
     pecl install -f redis-2.2.8 && \
     pecl install -f imagick
+
+RUN pecl install igbinary && \
+    docker-php-ext-enable igbinary && \
+    apt-get install -y libmemcached-dev=1.0.18-4.1 && \
+    pecl download memcached-2.2.0 && \
+    tar xzvf memcached-2.2.0.tgz && \
+    cd memcached-2.2.0 && \
+    phpize && \
+    ./configure --enable-memcached-igbinary --disable-memcached-sasl && \
+    make && \
+    make install
 
 RUN docker-php-ext-enable mongo memcached redis imagick
 

--- a/apache-php/Makefile
+++ b/apache-php/Makefile
@@ -1,5 +1,5 @@
 IMG_NAME := bufferapp/apache-php
-IMG_VERSION := 5.6.36-apache-stretch
+IMG_VERSION := 5.6.36-apache-stretch-igbinary
 
 .PHONY: build
 build:


### PR DESCRIPTION
Hey @djfarrelly I think you meant to add igbinary for both `php-apache` and `php56-cli`

There is 2 base images: one with apache `php-apache` , and one without it `php56-cli`

The image `bufferapp/apache-php:5.6.36-apache-stretch-igbinary` was not present in dockerhub so I've just push it

https://buffer.slack.com/archives/C0DLFPGG5/p1533288746000251