### PR TITLE
Mongodb driver v1.3.4

### DIFF
--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
 # Drivers and libraries
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
 RUN docker-php-ext-install -j$(nproc) gd mcrypt calendar pcntl
-RUN pecl install -f mongo-1.5.8 && \
+RUN pecl install -f mongodb-1.5.2 && \
     pecl install -f redis-2.2.8 && \
     pecl install -f imagick && \
     pecl install igbinary && \
@@ -37,7 +37,7 @@ RUN pecl install -f mongo-1.5.8 && \
     ./configure --enable-memcached-igbinary --disable-memcached-sasl && \
     make && \
     make install && \
-    docker-php-ext-enable mongo memcached redis imagick
+    docker-php-ext-enable mongodb memcached redis imagick
 
 # Configure Apache
 COPY php.ini /usr/local/etc/php/

--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -17,10 +17,6 @@ RUN apt-get update && \
       libz-dev \
       unzip \
       zip
-#      php-pear \     # help to install some extentions
-#      php5-dev \     # get the headers for some extensions
-#      php5-cli \     # I don't think we need that
-
 
 # Drivers and libraries
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/

--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
       libmemcached-dev \
       libmcrypt-dev \
       libcurl3 \
+      libssl-dev \
       libfreetype6-dev \
       libjpeg62-turbo-dev \
       libjpeg-dev \
@@ -24,7 +25,7 @@ RUN apt-get update && \
 # Drivers and libraries
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
 RUN docker-php-ext-install -j$(nproc) gd mcrypt calendar pcntl
-RUN pecl install -f mongodb-1.4.4 && \
+RUN pecl install -f mongodb-1.3.4 && \
     pecl install -f redis-2.2.8 && \
     pecl install -f imagick && \
     pecl install igbinary && \

--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
 # Drivers and libraries
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
 RUN docker-php-ext-install -j$(nproc) gd mcrypt calendar pcntl
-RUN pecl install -f mongodb-1.5.2 && \
+RUN pecl install -f mongodb-1.4.4 && \
     pecl install -f redis-2.2.8 && \
     pecl install -f imagick && \
     pecl install igbinary && \

--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Steven Cheng <steven@buffer.com>
 RUN apt-get update && \
       apt-get -yq install \
       build-essential \
-      libmagickwand-dev \ 
+      libmagickwand-dev \
       libmemcached-dev \
       libmcrypt-dev \
       libcurl3 \
@@ -26,9 +26,8 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
 RUN docker-php-ext-install -j$(nproc) gd mcrypt calendar pcntl
 RUN pecl install -f mongo-1.5.8 && \
     pecl install -f redis-2.2.8 && \
-    pecl install -f imagick
-
-RUN pecl install igbinary && \
+    pecl install -f imagick && \
+    pecl install igbinary && \
     docker-php-ext-enable igbinary && \
     apt-get install -y libmemcached-dev=1.0.18-4.1 && \
     pecl download memcached-2.2.0 && \
@@ -37,9 +36,8 @@ RUN pecl install igbinary && \
     phpize && \
     ./configure --enable-memcached-igbinary --disable-memcached-sasl && \
     make && \
-    make install
-
-RUN docker-php-ext-enable mongo memcached redis imagick
+    make install && \
+    docker-php-ext-enable mongo memcached redis imagick
 
 # Configure Apache
 COPY php.ini /usr/local/etc/php/

--- a/apache-php/Makefile
+++ b/apache-php/Makefile
@@ -1,5 +1,5 @@
 IMG_NAME := bufferapp/apache-php
-IMG_VERSION := 5.6.36-apache-stretch-igbinary
+IMG_VERSION := 5.6.36-apache-stretch-igbinary-mongodb-1.3.4
 
 .PHONY: build
 build:

--- a/php56-cli/Dockerfile
+++ b/php56-cli/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get -yq install \
       build-essential \
       libmemcached-dev \
       libmcrypt-dev \
+      libssl-dev \
       libfreetype6-dev \
       libjpeg62-turbo-dev \
       libjpeg-dev \
@@ -24,15 +25,10 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
 
 RUN apt-get -y install nano vim
 
-# Install Composer
-RUN curl -sS https://getcomposer.org/installer | \
-      php -- --install-dir=/usr/local/bin --filename=composer
-
 # Install drivers and activate
-RUN pecl install mongo-1.4.5
-RUN pecl install redis-2.2.4
-# pecl memcached does not support igbinary
-RUN pecl install igbinary && \
+RUN pecl install -f mongodb-1.3.4 && \
+    pecl install redis-2.2.4 && \
+    pecl install igbinary && \
     docker-php-ext-enable igbinary && \
     apt-get install -y libmemcached-dev=1.0.18-4.1 && \
     pecl download memcached-2.2.0 && \
@@ -41,8 +37,8 @@ RUN pecl install igbinary && \
     phpize && \
     ./configure --enable-memcached-igbinary --disable-memcached-sasl && \
     make && \
-    make install
-RUN docker-php-ext-enable mongo memcached redis
+    make install && \
+    docker-php-ext-enable mongodb memcached redis
 
 RUN mkdir -p /var/www/html
 

--- a/php56-cli/Makefile
+++ b/php56-cli/Makefile
@@ -1,5 +1,5 @@
 IMG_NAME := bufferapp/php56-cli
-IMG_VERSION := 5.6.36-cli-stretch-igbinary
+IMG_VERSION := 5.6.36-cli-stretch-igbinary-mongodb-1.3.4
 
 .PHONY: build
 build:


### PR DESCRIPTION
### Purpose
To support the mongo driver upgrade in buffer-web in https://github.com/bufferapp/buffer-web/pull/15448.

New images:
* `bufferapp/apache-php:5.6.36-apache-stretch-igbinary-mongodb-1.3.4`
* `bufferapp/php56-cli:5.6.36-cli-stretch-igbinary-mongodb-1.3.4`

### Notes
- Had to add libssl. See related https://github.com/mongodb/mongo-php-driver/issues/538 and http://php.net/manual/en/mongodb.installation.pecl.php