### PR TITLE
Support intl in php 56 and php71

### DIFF
--- a/apache-php/5.6/Dockerfile
+++ b/apache-php/5.6/Dockerfile
@@ -22,8 +22,10 @@ RUN docker-php-ext-install -j$(nproc) gd mcrypt calendar pcntl
 RUN pecl install -f mongodb-1.3.4 && \
     pecl install -f redis-4.1.1 && \
     pecl install -f imagick && \
-    pecl install igbinary && \
+    pecl install igbinary-1.2.1 && \
     docker-php-ext-enable igbinary && \
+    pecl install intl && \
+    docker-php-ext-enable intl && \
     apt-get install -y libmemcached-dev=1.0.18-4.1 && \
     pecl download memcached-2.2.0 && \
     tar xzvf memcached-2.2.0.tgz && \

--- a/apache-php/5.6/Makefile
+++ b/apache-php/5.6/Makefile
@@ -1,5 +1,5 @@
 IMG_NAME := bufferapp/apache-php
-IMG_VERSION := 5.6.39-apache-stretch-igbinary-mongodb-1.3.4
+IMG_VERSION := 5.6.39-apache-stretch-igbinary-mongodb-1.3.4-intl
 
 .PHONY: build
 build:

--- a/apache-php/7.1/Dockerfile
+++ b/apache-php/7.1/Dockerfile
@@ -14,11 +14,16 @@ RUN apt-get update && \
       libpng-dev \
       libz-dev \
       unzip \
-      zip
+      zip \
+      libicu-dev
 
 # Drivers and libraries
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
     docker-php-ext-install -j$(nproc) gd mcrypt calendar pcntl
+
+RUN docker-php-ext-configure intl && \
+    docker-php-ext-install intl
+
 RUN pecl install -f mongodb-1.3.4 && \
     pecl install -f redis-4.1.1 && \
     pecl install -f imagick && \

--- a/apache-php/7.1/Makefile
+++ b/apache-php/7.1/Makefile
@@ -1,5 +1,5 @@
 IMG_NAME := bufferapp/apache-php
-IMG_VERSION := 7.1.25-apache-stretch-igbinary-mongodb-1.3.4
+IMG_VERSION := 7.1.25-apache-stretch-igbinary-mongodb-1.3.4-intl
 
 .PHONY: build
 build:


### PR DESCRIPTION
In order to fix https://buffer.atlassian.net/browse/PUB-649, we need to support the intl library.

This is a pre-requisite for https://github.com/bufferapp/buffer-web/pull/15899.

@erickhun - would love your thoughts on this one! I did put in an explicit igbinary version while I was here, since I wanted to keep things as similar as possible to the existing image.

The approach differs a bit from 5.6 to 7.1, which took a while to unravel!