### PR TITLE
Upgrade PHP to 7.1.33 INFRA-83

### DIFF
--- a/apache-php/7.1/Dockerfile
+++ b/apache-php/7.1/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update && \
 
 # Drivers and libraries
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
-    docker-php-ext-install -j$(nproc) gd mcrypt calendar pcntl sockets
+    docker-php-ext-configure opcache --enable-opcache && \
+    docker-php-ext-install -j$(nproc) gd mcrypt calendar pcntl sockets opcache exif
 
 RUN pecl install -f mongodb-1.5.3 && \
     pecl install -f redis-4.1.1 && \
@@ -35,6 +36,17 @@ RUN pecl install -f mongodb-1.5.3 && \
     make && \
     make install && \
     docker-php-ext-enable mongodb memcached redis imagick
+
+# Configure Opcode cache https://www.scalingphpbook.com/blog/2014/02/14/best-zend-opcache-settings.html
+RUN ( \
+  echo "opcache.memory_consumption=192"; \
+  echo "opcache.interned_strings_buffer=8"; \
+  echo "opcache.max_accelerated_files=25000"; \
+  echo ";opcache.revalidate_freq=2"; \
+  echo "opcache.validate_timestamps=0"; \
+  echo "opcache.fast_shutdown=1"; \
+  echo ";opcache.enable_cli=0"; \
+  ) > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # Configure Apache
 COPY php.ini /usr/local/etc/php/

--- a/apache-php/7.1/Dockerfile
+++ b/apache-php/7.1/Dockerfile
@@ -18,8 +18,7 @@ RUN apt-get update && \
 
 # Drivers and libraries
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
-    docker-php-ext-configure opcache --enable-opcache && \
-    docker-php-ext-install -j$(nproc) gd mcrypt calendar pcntl sockets opcache exif
+    docker-php-ext-install -j$(nproc) gd mcrypt calendar pcntl sockets exif
 
 RUN pecl install -f mongodb-1.5.3 && \
     pecl install -f redis-4.1.1 && \
@@ -36,17 +35,6 @@ RUN pecl install -f mongodb-1.5.3 && \
     make && \
     make install && \
     docker-php-ext-enable mongodb memcached redis imagick
-
-# Configure Opcode cache https://www.scalingphpbook.com/blog/2014/02/14/best-zend-opcache-settings.html
-RUN ( \
-  echo "opcache.memory_consumption=192"; \
-  echo "opcache.interned_strings_buffer=8"; \
-  echo "opcache.max_accelerated_files=25000"; \
-  echo ";opcache.revalidate_freq=2"; \
-  echo "opcache.validate_timestamps=0"; \
-  echo "opcache.fast_shutdown=1"; \
-  echo ";opcache.enable_cli=0"; \
-  ) > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # Configure Apache
 COPY php.ini /usr/local/etc/php/

--- a/apache-php/7.1/Dockerfile
+++ b/apache-php/7.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1.27-apache-stretch
+FROM php:7.1.32-apache-stretch
 
 RUN apt-get update && \
       apt-get -yq install \

--- a/apache-php/7.1/Dockerfile
+++ b/apache-php/7.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1.32-apache-stretch
+FROM php:7.1.33-apache-stretch
 
 RUN apt-get update && \
       apt-get -yq install \
@@ -26,6 +26,7 @@ RUN pecl install -f mongodb-1.5.3 && \
     pecl install igbinary-2.0.8 && \
     docker-php-ext-enable igbinary && \
     apt-get install -y libmemcached-dev=1.0.18-4.1 && \
+    apt-get upgrade -y tzdata=2019c-0+deb9u1 && \
     pecl download memcached-3.0.4 && \
     tar xzvf memcached-3.0.4.tgz && \
     cd memcached-3.0.4 && \

--- a/apache-php/7.1/Makefile
+++ b/apache-php/7.1/Makefile
@@ -1,5 +1,5 @@
 IMG_NAME := bufferapp/apache-php
-IMG_VERSION := 7.1.27
+IMG_VERSION := 7.1.32
 
 .PHONY: build
 build:

--- a/apache-php/7.1/Makefile
+++ b/apache-php/7.1/Makefile
@@ -1,5 +1,5 @@
 IMG_NAME := bufferapp/apache-php
-IMG_VERSION := 7.1.32
+IMG_VERSION := 7.1.33
 
 .PHONY: build
 build:

--- a/php-cli/7.1/Dockerfile
+++ b/php-cli/7.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1.32-cli-stretch
+FROM php:7.1.33-cli-stretch
 
 RUN apt-get update && \
       apt-get -yq install \
@@ -30,6 +30,7 @@ RUN pecl install -f mongodb-1.5.3 && \
     pecl install igbinary-2.0.8 && \
     docker-php-ext-enable igbinary && \
     apt-get install -y libmemcached-dev=1.0.18-4.1 && \
+    apt-get upgrade -y tzdata=2019c-0+deb9u1 && \
     pecl download memcached-3.0.4 && \
     tar xzvf memcached-3.0.4.tgz && \
     cd memcached-3.0.4 && \

--- a/php-cli/7.1/Dockerfile
+++ b/php-cli/7.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1.27-cli-stretch
+FROM php:7.1.32-cli-stretch
 
 RUN apt-get update && \
       apt-get -yq install \

--- a/php-cli/7.1/Dockerfile
+++ b/php-cli/7.1/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
     docker-php-ext-install -j$(nproc) gd mcrypt calendar pcntl &&\
     docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql &&\
-    docker-php-ext-install pdo pdo_pgsql pgsql sockets
+    docker-php-ext-install pdo pdo_pgsql pgsql sockets exif
 
 RUN pecl install -f mongodb-1.5.3 && \
     pecl install -f redis-4.1.1 && \

--- a/php-cli/7.1/Makefile
+++ b/php-cli/7.1/Makefile
@@ -1,5 +1,5 @@
 IMG_NAME := bufferapp/php-cli
-IMG_VERSION := 7.1.27
+IMG_VERSION := 7.1.32
 
 .PHONY: build
 build:

--- a/php-cli/7.1/Makefile
+++ b/php-cli/7.1/Makefile
@@ -1,5 +1,5 @@
 IMG_NAME := bufferapp/php-cli
-IMG_VERSION := 7.1.32
+IMG_VERSION := 7.1.33
 
 .PHONY: build
 build:


### PR DESCRIPTION
No breaking changes, mostly small security updates and bug fixes https://www.php.net/ChangeLog-7.php#PHP_7_1

@colinscape up for a review? 


Also, maybe we should think a bit more on the naming the image and tags:

- For tags , I use the php minor version upgrades as an opportunity to change the image (adding libs and co)  , but it will might happen some time where there is no minor upgrade 
- For naming the image, maybe we can simply use our product names? since analyze stack != publish stack != reply stack != core stack. The downside with that is that we could endup with few base image per product 🤔 . I'm thinking something 3 base images per team : `teamX-workers` `teamX-backend` `teamX-frontend`. what will results 12 total base images for our 4 team. That's still a lot to maintain. 