### PR TITLE
Upgrade node-libvips to node 12

### DIFF
--- a/node-libvips/Dockerfile
+++ b/node-libvips/Dockerfile
@@ -6,5 +6,5 @@ RUN \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
   gobject-introspection gtk-doc-tools libglib2.0-dev  libjpeg62-turbo-dev \
   libpng12-dev libwebp-dev libtiff5-dev libexif-dev libxml2-dev swig libmagickwand-dev libpango1.0-dev \
-  libmatio-dev libopenslide-dev libcfitsio3-dev \
+  libmatio-dev libopenslide-dev libcfitsio-dev \
   libvips libvips-dev

--- a/node-libvips/Dockerfile
+++ b/node-libvips/Dockerfile
@@ -4,7 +4,7 @@ RUN \
   # Install dependencies
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
-  gobject-introspection gtk-doc-tools libglib2.0-dev  libjpeg62-turbo-dev \
-  libwebp-dev libtiff5-dev libexif-dev libxml2-dev swig libmagickwand-dev libpango1.0-dev \
-  libmatio-dev libopenslide-dev libcfitsio-dev \
+  # gobject-introspection gtk-doc-tools libglib2.0-dev  libjpeg62-turbo-dev \
+  # libwebp-dev libtiff5-dev libexif-dev libxml2-dev swig libmagickwand-dev libpango1.0-dev \
+  # libmatio-dev libopenslide-dev libcfitsio-dev \
   libvips libvips-dev

--- a/node-libvips/Dockerfile
+++ b/node-libvips/Dockerfile
@@ -1,4 +1,4 @@
-FROM 12.13.1-stretch
+FROM node:12.13.1-stretch
 
 RUN \
   # Install dependencies

--- a/node-libvips/Dockerfile
+++ b/node-libvips/Dockerfile
@@ -1,35 +1,7 @@
-FROM node:6.9.2-slim
-
-# Inspired by from https://github.com/marcbachmann/dockerfile-libvips/blob/master/Dockerfile
-ENV LIBVIPS_VERSION_MAJOR 8
-ENV LIBVIPS_VERSION_MINOR 4
-ENV LIBVIPS_VERSION_PATCH 5
-ENV LIBVIPS_VERSION $LIBVIPS_VERSION_MAJOR.$LIBVIPS_VERSION_MINOR.$LIBVIPS_VERSION_PATCH
+FROM 12.13.1-stretch
 
 RUN \
-
   # Install dependencies
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
-  automake build-essential curl \
-  gobject-introspection gtk-doc-tools libglib2.0-dev  libjpeg62-turbo-dev \
-  libpng12-dev libwebp-dev libtiff5-dev libexif-dev libxml2-dev swig libmagickwand-dev libpango1.0-dev \
-  libmatio-dev libopenslide-dev libcfitsio3-dev && \
-
-  # Build libvips
-  curl -O http://www.vips.ecs.soton.ac.uk/supported/$LIBVIPS_VERSION_MAJOR.$LIBVIPS_VERSION_MINOR/vips-$LIBVIPS_VERSION.tar.gz && \
-  tar zvxf vips-$LIBVIPS_VERSION.tar.gz && \
-  cd vips-$LIBVIPS_VERSION && \
-  ./configure --enable-debug=no --without-python --without-orc --without-fftw --without-gsf $1 && \
-  make && \
-  make install && \
-  ldconfig && \
-
-  # Clean up
-  apt-get remove -y curl automake build-essential && \
-  apt-get autoremove -y && \
-  apt-get autoclean && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-ADD policy.xml /etc/ImageMagick-6/
+  libvips libvips-dev

--- a/node-libvips/Dockerfile
+++ b/node-libvips/Dockerfile
@@ -5,6 +5,6 @@ RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
   gobject-introspection gtk-doc-tools libglib2.0-dev  libjpeg62-turbo-dev \
-  libpng12-dev libwebp-dev libtiff5-dev libexif-dev libxml2-dev swig libmagickwand-dev libpango1.0-dev \
+  libwebp-dev libtiff5-dev libexif-dev libxml2-dev swig libmagickwand-dev libpango1.0-dev \
   libmatio-dev libopenslide-dev libcfitsio-dev \
   libvips libvips-dev

--- a/node-libvips/Dockerfile
+++ b/node-libvips/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.13.1-stretch
+FROM node:12.13.1-stretch-slim
 
 RUN \
   # Install dependencies

--- a/node-libvips/Dockerfile
+++ b/node-libvips/Dockerfile
@@ -4,4 +4,7 @@ RUN \
   # Install dependencies
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  gobject-introspection gtk-doc-tools libglib2.0-dev  libjpeg62-turbo-dev \
+  libpng12-dev libwebp-dev libtiff5-dev libexif-dev libxml2-dev swig libmagickwand-dev libpango1.0-dev \
+  libmatio-dev libopenslide-dev libcfitsio3-dev \
   libvips libvips-dev


### PR DESCRIPTION
We can now simplify the `libvips` package install with https://github.com/libvips/libvips/wiki/Build-for-Ubuntu