### PR TITLE
Optimize node-libvips Docker image size

### DIFF
--- a/node-libvips/Dockerfile
+++ b/node-libvips/Dockerfile
@@ -3,7 +3,7 @@ FROM node:12-stretch-slim
 RUN \
   # Install dependencies
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   # gobject-introspection gtk-doc-tools libglib2.0-dev  libjpeg62-turbo-dev \
   # libwebp-dev libtiff5-dev libexif-dev libxml2-dev swig libmagickwand-dev libpango1.0-dev \
   # libmatio-dev libopenslide-dev libcfitsio-dev \

--- a/node-libvips/Dockerfile
+++ b/node-libvips/Dockerfile
@@ -7,4 +7,5 @@ RUN \
   # gobject-introspection gtk-doc-tools libglib2.0-dev  libjpeg62-turbo-dev \
   # libwebp-dev libtiff5-dev libexif-dev libxml2-dev swig libmagickwand-dev libpango1.0-dev \
   # libmatio-dev libopenslide-dev libcfitsio-dev \
-  libvips libvips-dev
+  libvips libvips-dev && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
By clearing the ```apt cache``` at the end of the layer (~10MB), and by using ```--no-install-recommends``` ```apt-get``` flag, a considerable amount can be shaped off from the ```node-libvips``` Docker image size.

```bash
$ docker images | grep buffer
buffer-node-libps                   latest                     3de1430475b9   55 seconds ago   685MB
buffer-node-libps                   original                   8cda3dc74678   8 minutes ago    1.25GB
```

May I ask you to point me to an example command that this image needs to be able to serve? That way I could validate, that nothing is missing by not installing additional recommended packages by ```apt```.

> Note: This might be a low impact fix, but ~550MB might take up to a few seconds to download upon deployment.
